### PR TITLE
Improve equation formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ An ARP memory field $G(t)$ evolves in parallel, storing information about the st
 
 Coupled equations:
 
-i\hbar\,\frac{d}{dt} \ket{\psi}
-= \big( H + \lambda\,\mathcal{A}[\psi,G] \big) \ket{\psi}
+$$
+i\hbar\,\frac{d}{dt} \ket{\psi} = \big( H + \lambda\,\mathcal{A}[\psi,G] \big) \ket{\psi}
+$$
 
+$$
 \dot{G} = \alpha\,\mathcal{I}[\psi] - \mu\,G
+$$
 
 Where:
 	•	$\lambda$ = state–memory coupling strength
@@ -39,7 +42,9 @@ Where:
 
 A natural choice:
 
+$$
 \mathcal{A}[\psi,G] = \nabla_{\text{state}}\, G(\psi)
+$$
 
 
 ⸻
@@ -48,9 +53,13 @@ A natural choice:
 
 A) Population-weighted memory
 
+$$
 \mathcal{I}[\psi] = \sum_j w_j \,\langle \psi | P_j | \psi \rangle \, P_j
+$$
 
+$$
 \dot{g}_j = \alpha w_j p_j - \mu g_j
+$$
 
 Here $\mathcal{A}$ is diagonal (detuning control).
 
@@ -58,11 +67,13 @@ B) Coherence-sensitive memory
 
 For $\rho = \ket{\psi}\bra{\psi}$:
 
-\dot{g}_x = \frac{\alpha}{2} x - \mu g_x
-
-\dot{g}_y = \frac{\alpha}{2} y - \mu g_y
-
-\mathcal{A} = g_x \sigma_x + g_y \sigma_y
+$$
+\begin{aligned}
+\dot{g}_x &= \frac{\alpha}{2} x - \mu g_x, \\
+\dot{g}_y &= \frac{\alpha}{2} y - \mu g_y, \\
+\mathcal{A} &= g_x \sigma_x + g_y \sigma_y
+\end{aligned}
+$$
 
 
 ⸻
@@ -71,19 +82,21 @@ For $\rho = \ket{\psi}\bra{\psi}$:
 
 Bare Hamiltonian:
 
+$$
 H = \frac{\hbar}{2} \big( \Delta\,\sigma_z + \Omega\,\sigma_x \big)
+$$
 
 Coupled Bloch–ARP system:
 
-\dot{x} = -\Delta y - 2\lambda g_y z
-
-\dot{y} = \Delta x - \Omega z + 2\lambda g_x z
-
-\dot{z} = \Omega y + 2\lambda(g_y x - g_x y)
-
-\dot{g}_x = \frac{\alpha}{2}x - \mu g_x
-
-\dot{g}_y = \frac{\alpha}{2}y - \mu g_y
+$$
+\begin{aligned}
+\dot{x} &= -\Delta y - 2\lambda g_y z, \\
+\dot{y} &= \Delta x - \Omega z + 2\lambda g_x z, \\
+\dot{z} &= \Omega y + 2\lambda(g_y x - g_x y), \\
+\dot{g}_x &= \frac{\alpha}{2}x - \mu g_x, \\
+\dot{g}_y &= \frac{\alpha}{2}y - \mu g_y
+\end{aligned}
+$$
 
 
 ⸻
@@ -92,7 +105,9 @@ Coupled Bloch–ARP system:
 
 Fast memory ($\mu \gg \alpha,\Omega,|\Delta|$)
 
+$$
 g_x \approx \frac{\alpha}{2\mu} x, \quad g_y \approx \frac{\alpha}{2\mu} y
+$$
 
 → Nonlinear detuning $\propto z$.
 
@@ -106,11 +121,17 @@ Slow memory ($\mu \ll \Omega,|\Delta|$)
 
 With Lindblad dissipation:
 
+$$
 \dot{\rho} = -\frac{i}{\hbar}[H+\lambda\mathcal{A},\rho]
-+ \Gamma_1 \mathcal{D}[\sigma_-]\rho
-+ \left( \Gamma_\phi + \eta g_y^2 \right) \mathcal{D}[\sigma_z]\rho
+ + \Gamma_1 \mathcal{D}[\sigma_-]\rho
+ + \left( \Gamma_\phi + \eta g_y^2 \right) \mathcal{D}[\sigma_z]\rho
+$$
 
-Where $\mathcal{D}[L]\rho = L\rho L^\dagger - \frac{1}{2}{L^\dagger L, \rho}$.
+Where
+
+$$
+\mathcal{D}[L]\rho = L\rho L^\dagger - \frac{1}{2}\{L^\dagger L, \rho\}.
+$$
 
 ⸻
 
@@ -119,14 +140,18 @@ Where $\mathcal{D}[L]\rho = L\rho L^\dagger - \frac{1}{2}{L^\dagger L, \rho}$.
 Sweeping $\Delta$ up/down under CW drive yields different steady-state branches for $z^\star(\Delta)$ when $\Lambda=\lambda\alpha/\mu>0$.
 	2.	Controllable decoherence floor:
 
+$$
 T_2^{-1}=\Gamma_2+\eta g_y^2
+$$
 
 Produces amplitude-dependent dephasing.
 
 	3.	Line-shape skew:
 Linear response acquires:
 
+$$
 \Lambda\frac{\Delta}{\Gamma_2-i\omega}
+$$
 
 → Odd-in-$\Delta$ asymmetry.
 
@@ -149,33 +174,3 @@ This framework generalizes Schrödinger dynamics with an ARP-based memory field,
 	•	Publish on arXiv
 
 ⸻
-
-If you want, I can add a runnable Python example right after this section so that someone cloning the repo can immediately simulate Predictions 1–3. That would make this README “interactive” and testable.
-
-Do you want me to add that next?
-\subsection{Slow memory limit ($\mu \ll \Omega,|\Delta|$)}
-Memory integrates the state history, producing hysteresis in phase shifts.
-
-\section{Open-System Extension}
-
-Adding Lindblad dissipation:
-\begin{align}
-\dot{\rho} &= -\frac{i}{\hbar}[H+\lambda\mathcal{A},\rho]
-+ \Gamma_1 \mathcal{D}[\sigma_-]\rho
-+ \left( \Gamma_\phi + \eta g_y^2 \right) \mathcal{D}[\sigma_z]\rho,
-\end{align}
-with $\mathcal{D}[L]\rho=L\rho L^\dagger - \frac{1}{2}\{L^\dagger L, \rho\}$.
-
-\section{Falsifiable Predictions}
-
-\begin{enumerate}
-\item \textbf{Hysteretic Rabi tip:} sweeping $\Delta$ up/down under CW drive yields different steady-state branches for $z^\star(\Delta)$ when $\Lambda=\lambda\alpha/\mu>0$.
-\item \textbf{Controllable decoherence floor:} $T_2^{-1}=\Gamma_2+\eta g_y^2$ produces amplitude-dependent dephasing.
-\item \textbf{Line-shape skew:} linear response acquires a term $\Lambda\frac{\Delta}{\Gamma_2-i\omega}$, producing an odd-in-$\Delta$ asymmetry.
-\end{enumerate}
-
-\section{Conclusion}
-This Adaptive--Quantum framework generalizes the Schr\"odinger equation with an ARP-based memory field, enabling tunable coherence, phase steering, and non-Markovian control.
-It provides both a theoretical foundation and clear experimental signatures for the proposed Bell--chip platform.
-
-\end{document}


### PR DESCRIPTION
## Summary
- render core model, memory, and dynamical equations using Markdown math blocks
- clarify open-system and predictions formulas with aligned LaTeX expressions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898bc35fa3c832fbca98c67649e225e